### PR TITLE
Raise the first probe point to the Z hop location to prevent "BLTouch failed to deploy"

### DIFF
--- a/auto_offset_z.py
+++ b/auto_offset_z.py
@@ -131,7 +131,7 @@ class AutoOffsetZCalibration:
 
         # Move with probe or bltouch to endstop XY position and test surface z position
         gcmd.respond_info("AutoOffsetZ: Probing endstop ...")
-        toolhead.manual_move([self.endstop_x_pos - self.x_offset, self.endstop_y_pos - self.y_offset], self.speed)
+        toolhead.manual_move([self.endstop_x_pos - self.x_offset, self.endstop_y_pos - self.y_offset, self.z_hop], self.speed)
         zendstop = self.printer.lookup_object('probe').run_probe(gcmd)
         # Perform Z Hop
         if self.z_hop:


### PR DESCRIPTION
In the case where the Z axis is homed right before running AUTO_OFFSET_Z, the BLTouch does not have enough room to deploy.